### PR TITLE
[Fix] Update rssi status

### DIFF
--- a/src/flockwave/server/model/uav.py
+++ b/src/flockwave/server/model/uav.py
@@ -312,6 +312,7 @@ class UAVBase(UAV):
         if len(rssi) <= index:
             rssi.extend([-1] * (index - len(rssi) + 1))
         rssi[index] = value
+        self.update_status(rssi=rssi)
         self._status.update_timestamp()
 
     def update_status(


### PR DESCRIPTION
Currently server reads in radio status packets but never actually sets the rssi on the `_status`  object of the UAV class, so downstream consumers never see it. This PR calls the `update_status` method to ensure rssi gets set accordingly.