### PR TITLE
Fix: do not sync clocks on auth/deauth

### DIFF
--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -69,14 +69,15 @@ class DroneShowConfiguration:
 
     updated = Signal(
         doc=(
-            "Signal emitted when the configuration is updated "
-            "(deprecated, use `updated_ext` instead!)"
+            "Signal emitted when the configuration is updated. Deprecated, use "
+            "`updated_v2` instead."
         )
     )
-    updated_ext = Signal(
+    updated_v2 = Signal(
         doc=(
-            "Extended signal emitted when the configuration is updated, "
-            "containing all names of member variables that got changed"
+            "Signal emitted when the configuration is updated. Provides a keyword "
+            "argument named `changes` that contains the names of all the affected "
+            "fields in the drone show configuration."
         )
     )
 
@@ -305,4 +306,4 @@ class DroneShowConfiguration:
             # Note that the old `updated` signal is deprecated and not used
             # any more, but we keep it for a while as maybe someone uses it
             self.updated.send(self)
-            self.updated_ext.send(self, changed=changed)
+            self.updated_v2.send(self, changed=changed)

--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -268,9 +268,9 @@ class DroneShowConfiguration:
                 if isinstance(uav_ids, list) and all(
                     item is None or isinstance(item, str) for item in uav_ids
                 ):
-                    # note that uav_ids is mutable, so we need to check whether we point to a
-                    # different list or whether the content of the same list has changed
-                    if self.uav_ids is not uav_ids or self.uav_ids != uav_ids:
+                    # TODO: If we exploit the mutability of uav_ids anywhere in the code
+                    # then this conditional assignment might cause trouble
+                    if set(self.uav_ids) != set(uav_ids):
                         self.uav_ids = uav_ids
                         changed.add("uav_ids")
 

--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -67,7 +67,18 @@ C = TypeVar("C", bound="DroneShowConfiguration")
 class DroneShowConfiguration:
     """Main configuration object for the drone show extension."""
 
-    updated = Signal(doc="Signal emitted when the configuration is updated")
+    updated = Signal(
+        doc=(
+            "Signal emitted when the configuration is updated "
+            "(deprecated, use `updated_ext` instead!)"
+        )
+    )
+    updated_ext = Signal(
+        doc=(
+            "Extended signal emitted when the configuration is updated, "
+            "containing all names of member variables that got changed"
+        )
+    )
 
     authorized_to_start: bool
     """Whether the show is authorized to start (subject to restrictions in
@@ -199,7 +210,7 @@ class DroneShowConfiguration:
 
     def update_from_json(self, obj: dict[str, Any]) -> None:
         """Updates the configuration object from its JSON representation."""
-        changed = False
+        changed: set[str] = set()
 
         # Handle start conditions
         start_conditions = obj.get("start")
@@ -207,7 +218,10 @@ class DroneShowConfiguration:
             if "authorized" in start_conditions:
                 # This is intentional; in order to be on the safe side, we only
                 # accept True for authorization, not any other truthy value
-                self.authorized_to_start = start_conditions["authorized"] is True
+                authorized_to_start = start_conditions["authorized"] is True
+                if self.authorized_to_start != authorized_to_start:
+                    self.authorized_to_start = authorized_to_start
+                    changed.add("authorized_to_start")
 
                 # For sake of compatibility with versions that did not have an
                 # authorizationScope member, force the scope to be LIVE if it
@@ -217,62 +231,80 @@ class DroneShowConfiguration:
                     and self.authorization_scope is AuthorizationScope.NONE
                 ):
                     self.authorization_scope = AuthorizationScope.LIVE
-
-                changed = True
+                    changed.add("authorization_scope")
 
             if "authorizationScope" in start_conditions:
                 authorization_scope = start_conditions["authorizationScope"]
                 if isinstance(authorization_scope, str):
                     try:
-                        self.authorization_scope = AuthorizationScope(
-                            authorization_scope
-                        )
-                        changed = True
+                        authorization_scope = AuthorizationScope(authorization_scope)
+                        if self.authorization_scope is not authorization_scope:
+                            self.authorization_scope = authorization_scope
+                            changed.add("authorization_scope")
                     except ValueError:
                         pass
 
             if "time" in start_conditions:
                 start_time = start_conditions["time"]
                 if start_time is None:
-                    self.start_time_on_clock = None
-                    changed = True
+                    if self.start_time_on_clock is not None:
+                        self.start_time_on_clock = None
+                        changed.add("start_time_on_clock")
                 elif isinstance(start_time, (int, float)):
-                    self.start_time_on_clock = float(start_time)
-                    changed = True
+                    start_time = float(start_time)
+                    if self.start_time_on_clock != start_time:
+                        self.start_time_on_clock = start_time
+                        changed.add("start_time_on_clock")
 
             if "method" in start_conditions:
-                self.start_method = StartMethod(start_conditions["method"])
-                changed = True
+                start_method = StartMethod(start_conditions["method"])
+                if self.start_method is not start_method:
+                    self.start_method = start_method
+                    changed.add("start_method")
 
             if "uavIds" in start_conditions:
                 uav_ids = start_conditions["uavIds"]
                 if isinstance(uav_ids, list) and all(
                     item is None or isinstance(item, str) for item in uav_ids
                 ):
-                    self.uav_ids = uav_ids
-                    changed = True
+                    # note that uav_ids is mutable, so we need to check whether we point to a
+                    # different list or whether the content of the same list has changed
+                    if self.uav_ids is not uav_ids or self.uav_ids != uav_ids:
+                        self.uav_ids = uav_ids
+                        changed.add("uav_ids")
 
             if "clock" in start_conditions:
                 clock = start_conditions["clock"]
                 if clock is None or isinstance(clock, str):
                     # Make sure that an empty string is mapped to None
-                    self.clock = clock if clock else None
-                    changed = True
+                    clock = clock if clock else None
+                    if self.clock != clock:
+                        self.clock = clock
+                        changed.add("clock")
 
         # Handle duration
         if "duration" in obj:
             if obj["duration"] is None:
-                self.duration = None
-                changed = True
+                if self.duration is not None:
+                    self.duration = None
+                    changed.add("duration")
             elif isinstance(obj["duration"], (int, float)) and obj["duration"] >= 0:
-                self.duration = float(obj["duration"])
-                changed = True
+                duration = float(obj["duration"])
+                if self.duration != duration:
+                    self.duration = duration
+                    changed.add("duration")
 
         # Enforce consistency of authorized_to_start and authorization_scope
         if self.authorized_to_start:
             if self.authorization_scope is AuthorizationScope.NONE:
-                self.authorized_to_start = False
-                changed = True
+                if self.authorized_to_start is True:
+                    self.authorized_to_start = False
+                    changed.add("authorized_to_start")
+
+        print("SHOW: update_from_json() changed", changed)
 
         if changed:
+            # Note that the old `updated` signal is deprecated and not used
+            # any more, but we keep it for a while as maybe someone uses it
             self.updated.send(self)
+            self.updated_ext.send(self, changed=changed)

--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -78,7 +78,8 @@ class DroneShowConfiguration:
         doc=(
             "Signal emitted when the configuration is updated. Provides a keyword "
             "argument named `changes` that contains the names of all the affected "
-            "fields in the drone show configuration."
+            "fields in the drone show configuration. The type of `changes` is "
+            "`Sequence[str]`."
         )
     )
 
@@ -305,4 +306,4 @@ class DroneShowConfiguration:
             # Note that the old `updated` signal is deprecated and not used
             # any more, but we keep it for a while as maybe someone uses it
             self.updated.send(self)
-            self.updated_v2.send(self, changed=changed)
+            self.updated_v2.send(self, changed=tuple(changed))

--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -301,8 +301,6 @@ class DroneShowConfiguration:
                     self.authorized_to_start = False
                     changed.add("authorized_to_start")
 
-        print("SHOW: update_from_json() changed", changed)
-
         if changed:
             # Note that the old `updated` signal is deprecated and not used
             # any more, but we keep it for a while as maybe someone uses it

--- a/src/flockwave/server/ext/show/config.py
+++ b/src/flockwave/server/ext/show/config.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from blinker import Signal
 
@@ -110,7 +111,7 @@ class DroneShowConfiguration:
     _seconds_ relative to the epoch of the existing clock.
     """
 
-    uav_ids: list[str | None]
+    uav_ids: Sequence[str | None]
     """The list of UAV IDs participating in the show."""
 
     def __init__(self):
@@ -265,13 +266,11 @@ class DroneShowConfiguration:
 
             if "uavIds" in start_conditions:
                 uav_ids = start_conditions["uavIds"]
-                if isinstance(uav_ids, list) and all(
+                if isinstance(uav_ids, Sequence) and all(
                     item is None or isinstance(item, str) for item in uav_ids
                 ):
-                    # TODO: If we exploit the mutability of uav_ids anywhere in the code
-                    # then this conditional assignment might cause trouble
-                    if set(self.uav_ids) != set(uav_ids):
-                        self.uav_ids = uav_ids
+                    if self.uav_ids != uav_ids:
+                        self.uav_ids = list(cast(Sequence[str | None], uav_ids))
                         changed.add("uav_ids")
 
             if "clock" in start_conditions:

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextlib import ExitStack
 from logging import Logger
 from math import inf
@@ -230,7 +231,7 @@ class DroneShowExtension(Extension):
         """Returns a copy of the current LED lgiht configuration."""
         return self._lights.clone()
 
-    def _on_config_updated(self, sender, changed: set[str]) -> None:
+    def _on_config_updated(self, sender, changed: Sequence[str]) -> None:
         """Handler that is called when the configuration of the start settings
         of the show was updated from any source.
 

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -233,6 +233,10 @@ class DroneShowExtension(Extension):
     def _on_config_updated(self, sender, changed: set[str]) -> None:
         """Handler that is called when the configuration of the start settings
         of the show was updated from any source.
+
+        Args:
+            changed: set of strings representing the member variables of the
+                show config object which has been actually updated
         """
         assert self.app is not None
 

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -240,7 +240,9 @@ class DroneShowExtension(Extension):
         """
         assert self.app is not None
 
-        if {"clock", "start_time_on_clock", "duration"} & changed:
+        if any(
+            prop in changed for prop in ("clock", "start_time_on_clock", "duration")
+        ):
             self._sync_show_clocks_to(
                 self._config.clock,
                 self._config.start_time_on_clock,

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -172,7 +172,7 @@ class DroneShowExtension(Extension):
 
             with ExitStack() as stack:
                 stack.enter_context(
-                    self._config.updated_ext.connected_to(
+                    self._config.updated_v2.connected_to(
                         self._on_config_updated,
                         sender=self._config,
                     )

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -172,7 +172,7 @@ class DroneShowExtension(Extension):
 
             with ExitStack() as stack:
                 stack.enter_context(
-                    self._config.updated.connected_to(
+                    self._config.updated_ext.connected_to(
                         self._on_config_updated,
                         sender=self._config,
                     )
@@ -230,15 +230,18 @@ class DroneShowExtension(Extension):
         """Returns a copy of the current LED lgiht configuration."""
         return self._lights.clone()
 
-    def _on_config_updated(self, sender) -> None:
+    def _on_config_updated(self, sender, changed: set[str]) -> None:
         """Handler that is called when the configuration of the start settings
         of the show was updated from any source.
         """
         assert self.app is not None
 
-        self._sync_show_clocks_to(
-            self._config.clock, self._config.start_time_on_clock, self._config.duration
-        )
+        if {"clock", "start_time_on_clock", "duration"} & changed:
+            self._sync_show_clocks_to(
+                self._config.clock,
+                self._config.start_time_on_clock,
+                self._config.duration,
+            )
 
         if self._show_tasks is not None:
             self._show_tasks.cancel_all()


### PR DESCRIPTION
This PR resolves the bug (if it was not a feature) that MTC clock got resynched to the show clock on pure auth/deauth requests from Live as the show config update automatically called clock resync for any config updates. Now it is more detailed and clock sync is only called when the relevant params of the show config has changed. 

However, if it was intentional to issue a final clock sync on auth before a show, then this needs to be re-added manually somehow.

PR tested and hopefully resolves the collective RTH bug found previously, so empty time axis config packets are no longer issued on deauth on Live during a show.