### PR TITLE
Increase websocket max message size to 100MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the drone, show "Waiting for takeoff time" instead of "Coutdown to start time" in
   the Details column in Skybrush Live to reassure the operator that the drone will
   take off when the time comes.
+
 - Increased maximum WebSocket message size to 100 MB by default.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the drone, show "Waiting for takeoff time" instead of "Coutdown to start time" in
   the Details column in Skybrush Live to reassure the operator that the drone will
   take off when the time comes.
+- Increased maximum WebSocket message size to 100 MB by default.
 
 ### Fixed
 

--- a/src/flockwave/server/ext/http_server/extension.py
+++ b/src/flockwave/server/ext/http_server/extension.py
@@ -423,11 +423,7 @@ schema = {
         "websocket_max_message_size": {
             "type": "integer",
             "title": "Max WebSocket message size",
-            "description": (
-                "Maximum size of a single WebSocket message in bytes. "
-                "Raise this if large messages (e.g., show files >16 MB) "
-                "are rejected by the server."
-            ),
+            "description": "Maximum size of a single WebSocket message in bytes.",
             "default": 104857600,
             "required": False,
         },

--- a/src/flockwave/server/ext/http_server/extension.py
+++ b/src/flockwave/server/ext/http_server/extension.py
@@ -301,6 +301,14 @@ async def run(app: SkybrushServer, configuration: dict[str, Any], logger: Logger
     config.keyfile = configuration.get("keyfile") or None
     config.use_reloader = False
 
+    config.websocket_max_message_size = int(
+        configuration.get("websocket_max_message_size", 104857600)
+    )
+    logger.info(
+        f"WebSocket max message size set to "
+        f"{config.websocket_max_message_size // 1024 // 1024} MB"
+    )
+
     secure = bool(config.ssl_enabled)
 
     # Test quickly whether we can bind to the given host and port; if we cannot,
@@ -410,6 +418,17 @@ schema = {
             "type": "string",
             "title": "Private key file",
             "description": "Full path to the private key file corresopnding to the certificate",
+            "required": False,
+        },
+        "websocket_max_message_size": {
+            "type": "integer",
+            "title": "Max WebSocket message size",
+            "description": (
+                "Maximum size of a single WebSocket message in bytes. "
+                "Raise this if large messages (e.g., show files >16 MB) "
+                "are rejected by the server."
+            ),
+            "default": 104857600,
             "required": False,
         },
     }

--- a/src/flockwave/server/ext/http_server/extension.py
+++ b/src/flockwave/server/ext/http_server/extension.py
@@ -302,10 +302,10 @@ async def run(app: SkybrushServer, configuration: dict[str, Any], logger: Logger
     config.use_reloader = False
 
     config.websocket_max_message_size = int(
-        configuration.get("websocket_max_message_size", 104857600)
+        configuration.get("websocket_max_message_size", 100 * 1024 * 1024)
     )
-    logger.info(
-        f"WebSocket max message size set to "
+    logger.debug(
+        f"WebSocket maximum message size is set to "
         f"{config.websocket_max_message_size // 1024 // 1024} MB"
     )
 
@@ -411,7 +411,10 @@ schema = {
         "certfile": {
             "type": "string",
             "title": "Certificate file",
-            "description": "Full path to the certificate file that the server should use for HTTPS connections",
+            "description": (
+                "Full path to the certificate file that the server should use for "
+                "HTTPS connections"
+            ),
             "required": False,
         },
         "keyfile": {
@@ -423,7 +426,10 @@ schema = {
         "websocket_max_message_size": {
             "type": "integer",
             "title": "Max WebSocket message size",
-            "description": "Maximum size of a single WebSocket message in bytes.",
+            "description": (
+                "Maximum size of a single WebSocket message in bytes. Used only for "
+                "clients that connect to the server via WebSocket."
+            ),
             "default": 104857600,
             "required": False,
         },


### PR DESCRIPTION
It can be configured with the `websocket_max_message_size` setting of the `http_server` extension.