### PR TITLE
WIP: Refactor extension configs to Pydantic

### DIFF
--- a/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
+++ b/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
@@ -11,10 +11,11 @@ Refactors a Skybrush server extension's configuration from a raw dict JSON schem
 
 Canonical examples of this refactor (view with `git show <hash>`):
 
-- `6fc14264` — `auth` extension: class-based, simple `bool` field
+- `6fc14264` — `auth` extension: class-based, simple `bool` field with `format: checkbox`
 - `d17f6235` — `show` extension: class-based, enum field with `WithJsonSchema` + `Annotated`
 - `5e4be6fe` — `auth_basic` extension: module-level (no class), nested array-of-objects schema
 - `c7a6638e` — `audit_log` extension: class-based, simple `float` field
+- `7893ff43` — batch of 5 extensions (`gps`, `http`, `insomnia`, `kp_index`, `location_from_uavs`) covering: `bool` with `format: checkbox`, `Literal` enum with `json_schema_extra`, `UAVExtension` → `TypedConfigExtension`, keep-config-in-run pattern
 
 Review these for a complete before/after picture.
 
@@ -53,14 +54,14 @@ For each field in the old `schema` dict, I will ask:
 
 ### 3. Convert the schema
 
-Create a `ConfigModel(BaseModel)` with:
+Create a `ConfigModel(BaseModel)` with the appropriate pattern per field type:
 
-- Simple types (`str`, `int`, `float`, `bool`) used as-is
-- Enum types kept as the Python type for validation, with `Annotated[EnumType, WithJsonSchema(...)]` to inline the JSON schema (avoids Pydantic v2's `$defs`/`$ref` which breaks the WebUI's JSONEditor v2.5.4)
-- `enum_titles` and other metadata in `WithJsonSchema` (not in `Field(json_schema_extra=...)` — `WithJsonSchema` replaces the generated schema entirely)
-- All strings derived from the enum class itself (e.g. `[m.value for m in MyEnum]`, `[m.describe() for m in MyEnum]`) to avoid duplication
+- **`str`, `int`, `float`** — used as-is with `Field(default=..., title=..., description=...)`. Simple types never generate `$defs`.
+- **`bool`** — used as-is. For `format: "checkbox"`, add via `Field(json_schema_extra={"format": "checkbox"})`. See `6fc14264` (auth) or `7893ff43` (insomnia).
+- **`Literal["a", "b"]`** — for string enum-like fields using `Literal` instead of an Enum class. Pydantic generates inline `enum` without `$defs`. Add `enum_titles` via `Field(json_schema_extra={"options": {"enum_titles": [...]}})`. See `7893ff43` (kp_index).
+- **Existing Enum class** — keep as the Python type for validation, wrap with `Annotated[EnumType, WithJsonSchema(...)]` to inline the JSON schema and avoid `$defs`/`$ref` (Pydantic v2 generates `$defs` for enum classes, which breaks the WebUI's JSONEditor v2.5.4). Put `enum_titles` and all metadata in `WithJsonSchema`, not in `Field(json_schema_extra=...)`. Derive values from the Enum class (e.g. `[m.value for m in MyEnum]`). See `d17f6235` (show).
 
-See `d17f6235` (show extension) for a full example.
+Key rule: `WithJsonSchema` replaces the field's generated schema entirely; `json_schema_extra` merges into it. Use `WithJsonSchema` only when Pydantic's auto-generated schema contains `$ref` (i.e. for Enum classes). For simple types and `Literal`, `json_schema_extra` is sufficient.
 
 ### 4. Change imports
 
@@ -72,8 +73,10 @@ See `d17f6235` (show extension) for a full example.
 
 The extension class must inherit from `TypedConfigExtension[ConfigModel]` instead of `Extension`.
 
-- Old: `class MyExtension(Extension):`
+- Old: `class MyExtension(Extension):` (or `class MyExtension(UAVExtension):`)
 - New: `class MyExtension(TypedConfigExtension[ConfigModel]):`
+
+When the old class extended `UAVExtension`, the switch to `TypedConfigExtension` means losing UAV-specific helpers (`_create_driver`, `configure_driver`, etc.). Store config values in private fields in `configure()` and pass them explicitly where needed. See `7893ff43` (gps) for an example.
 
 The `TypedConfigExtension` base class (from `flockwave.server.ext.base`) provides:
 - `self.config` — the validated Pydantic model instance, available after `configure()` is called
@@ -92,13 +95,13 @@ def configure(self, configuration: ConfigModel) -> None:
 
 ### 7. Update `run()` method
 
-In the standard pattern:
+In the standard class-based pattern:
 - Remove `configuration` and `logger` parameters
 - Signature becomes `async def run(self, app):`
 - Use `self.log` instead of the `logger` parameter
 - Any config-dependent setup that was in `run` should already be in `configure()`
 
-However, some extensions may still need `configuration` and `logger` as parameters if `run()` is invoked directly by other code rather than solely through the extension manager lifecycle.
+However, some extensions may still need `configuration` and `logger` as parameters if `run()` is invoked directly by other code rather than solely through the extension manager lifecycle. Module-level extensions (no class) always keep `configuration` and `logger` — the function signature stays `async def run(app, configuration: ConfigModel, logger)`. See `7893ff43` (http, insomnia, kp_index) for examples.
 
 ### 8. Update module-level variables
 
@@ -120,6 +123,8 @@ For these, we keep the existing structure and only replace the `schema` dict wit
 3. Replace the `schema` dict with `schema = ConfigModel`
 4. Update `run()` to use attribute access on the typed `configuration` parameter (e.g. `configuration.sources` instead of `configuration.get("sources", ())`)
 5. Remove any validation logic that becomes redundant (Pydantic validates types/defaults)
+
+For simple string enums with no existing Enum class, prefer `Literal["a", "b"]` over creating a new Enum — Pydantic inlines the enum values without `$defs`. See `7893ff43` (kp_index) for an example.
 
 ### Nested schemas (arrays of objects)
 

--- a/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
+++ b/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
@@ -65,6 +65,8 @@ Create a `ConfigModel(BaseModel)` with the appropriate pattern per field type:
 
 Key rule: `WithJsonSchema` replaces the field's generated schema entirely; `json_schema_extra` merges into it. Use `WithJsonSchema` only when Pydantic's auto-generated schema contains `$ref` (i.e. for Enum classes). For simple types and `Literal`, `json_schema_extra` is sufficient.
 
+**IMPORTANT: Preserve `propertyOrder`** — every field in the old schema may have `"propertyOrder": <int>` which controls the layout order in the WebUI. Add it via `json_schema_extra={"propertyOrder": N}` for simple types, or inside the `WithJsonSchema` dict for Enum types/nested objects. Without it, the WebUI form fields appear in an unpredictable order.
+
 ### 4. Change imports
 
 - Replace `from flockwave.server.ext.base import Extension` with `from flockwave.server.ext.base import TypedConfigExtension`

--- a/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
+++ b/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
@@ -67,6 +67,8 @@ Key rule: `WithJsonSchema` replaces the field's generated schema entirely; `json
 
 **IMPORTANT: Preserve `propertyOrder`** — every field in the old schema may have `"propertyOrder": <int>` which controls the layout order in the WebUI. Add it via `json_schema_extra={"propertyOrder": N}` for simple types, or inside the `WithJsonSchema` dict for Enum types/nested objects. Without it, the WebUI form fields appear in an unpredictable order.
 
+**IMPORTANT: Preserve `"required": False`** — some fields have `"required": False` on the property itself. This is **not** standard JSON Schema (where `required` is an object-level array). It is a project convention to mark fields as optional at the UI level. The WebUI uses it to know which fields can be omitted from the config. Add it via `json_schema_extra={"required": False}` for simple types, or inside the `WithJsonSchema` dict for Enum types/nested objects. Without it, fields that were explicitly optional may lose that UI hint.
+
 ### 4. Change imports
 
 - Replace `from flockwave.server.ext.base import Extension` with `from flockwave.server.ext.base import TypedConfigExtension`

--- a/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
+++ b/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pydantic-refactor-of-ext-config
 description: Refactors a Skybrush server extension's configuration from a raw dict JSON schema to a Pydantic model. For class-based extensions the base class becomes TypedConfigExtension; for module-level extensions (no class) only the schema is replaced.
+constraints: |
+  - **DO NOT** refactor extensions that have `schema = {}` (empty dict). They expose no user-facing config and the refactor is unnecessary. Some still parse `configuration` internally — those are deliberately opaque and should be left as-is.
 ---
 
 # Skill: Pydantic Refactor of Extension Config
@@ -150,3 +152,4 @@ No class inheritance changes, no `configure()` method, no `TypedConfigExtension`
 - NEVER push.
 - Work on one extension at a time.
 - Ask before making changes that differ from this pattern.
+- **DO NOT** refactor extensions that have `schema = {}` (empty dict). They expose no user-facing config and the refactor is unnecessary. Some still parse `configuration` internally — those are deliberately opaque and should be left as-is.

--- a/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
+++ b/.agents/skills/pydantic-refactor-of-ext-config/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pydantic-refactor-of-ext-config
+description: Refactors a Skybrush server extension's configuration from a raw dict JSON schema to a Pydantic model. For class-based extensions the base class becomes TypedConfigExtension; for module-level extensions (no class) only the schema is replaced.
+---
+
+# Skill: Pydantic Refactor of Extension Config
+
+Refactors a Skybrush server extension's configuration from a raw dict JSON schema to a Pydantic model. For class-based extensions the base class becomes `TypedConfigExtension`; for module-level extensions (no class) only the `schema` is replaced.
+
+## Reference
+
+Canonical examples of this refactor (view with `git show <hash>`):
+
+- `6fc14264` — `auth` extension: class-based, simple `bool` field
+- `d17f6235` — `show` extension: class-based, enum field with `WithJsonSchema` + `Annotated`
+- `5e4be6fe` — `auth_basic` extension: module-level (no class), nested array-of-objects schema
+- `c7a6638e` — `audit_log` extension: class-based, simple `float` field
+
+Review these for a complete before/after picture.
+
+## Process
+
+I will guide you through each extension one at a time. For each extension I will:
+
+1. Read the current extension code and config schema
+2. Ask you questions about the config fields
+3. Apply the rewrite
+4. Verify with lint and tests
+
+## Prerequisites
+
+Run this from the project root (where `pyproject.toml` lives).
+
+---
+
+## Step-by-step for each extension
+
+### 1. Locate the extension
+
+I will find the extension files. Extensions are in `src/flockwave/server/ext/` — either a single `<name>.py` or a package `<name>/` with `extension.py`.
+
+I will read the module-level `schema` dict and the `run` method to understand what config fields exist.
+
+### 2. Ask about config fields
+
+For each field in the old `schema` dict, I will ask:
+
+- **Field name** — already known from the schema
+- **Pydantic type** — `str`, `int`, `float`, `bool`, or an existing enum class
+- **Default value** — already known from the schema
+- **Title and description** — already known from the schema
+- **Any enum-related display metadata** — `options.enum_titles` etc.
+
+### 3. Convert the schema
+
+Create a `ConfigModel(BaseModel)` with:
+
+- Simple types (`str`, `int`, `float`, `bool`) used as-is
+- Enum types kept as the Python type for validation, with `Annotated[EnumType, WithJsonSchema(...)]` to inline the JSON schema (avoids Pydantic v2's `$defs`/`$ref` which breaks the WebUI's JSONEditor v2.5.4)
+- `enum_titles` and other metadata in `WithJsonSchema` (not in `Field(json_schema_extra=...)` — `WithJsonSchema` replaces the generated schema entirely)
+- All strings derived from the enum class itself (e.g. `[m.value for m in MyEnum]`, `[m.describe() for m in MyEnum]`) to avoid duplication
+
+See `d17f6235` (show extension) for a full example.
+
+### 4. Change imports
+
+- Replace `from flockwave.server.ext.base import Extension` with `from flockwave.server.ext.base import TypedConfigExtension`
+- Add `from pydantic import BaseModel, Field, WithJsonSchema`
+- Add `from typing import Annotated`
+
+### 5. Change the class
+
+The extension class must inherit from `TypedConfigExtension[ConfigModel]` instead of `Extension`.
+
+- Old: `class MyExtension(Extension):`
+- New: `class MyExtension(TypedConfigExtension[ConfigModel]):`
+
+The `TypedConfigExtension` base class (from `flockwave.server.ext.base`) provides:
+- `self.config` — the validated Pydantic model instance, available after `configure()` is called
+- `configure(configuration: ConfigModel)` — called automatically during `load()` after `self.log` and `self.app` are set
+- The `run()` method no longer receives `configuration` or `logger` — they are available via `self.config` and `self.log`
+
+### 6. Add `configure()` method
+
+Move config reading logic from `run()` here. The config is already validated when this is called.
+
+```python
+def configure(self, configuration: ConfigModel) -> None:
+    self._some_field = configuration.some_field
+    # ... convert enum fields if needed ...
+```
+
+### 7. Update `run()` method
+
+In the standard pattern:
+- Remove `configuration` and `logger` parameters
+- Signature becomes `async def run(self, app):`
+- Use `self.log` instead of the `logger` parameter
+- Any config-dependent setup that was in `run` should already be in `configure()`
+
+However, some extensions may still need `configuration` and `logger` as parameters if `run()` is invoked directly by other code rather than solely through the extension manager lifecycle.
+
+### 8. Update module-level variables
+
+- Replace the dict `schema = {...}` with `schema = ConfigModel`
+- Keep `construct = MyExtension`, `dependencies`, `description` as-is (unless they also need updating)
+
+---
+
+## Variation: Module-level extensions (no class)
+
+Some extensions have no class — just an `async def run()` function at module level and no `construct`. The module itself IS the extension instance.
+
+For these, we keep the existing structure and only replace the `schema` dict with a Pydantic model:
+
+### Changes needed
+
+1. Add `from pydantic import BaseModel, Field`
+2. Create a `ConfigModel(BaseModel)` class in the same file
+3. Replace the `schema` dict with `schema = ConfigModel`
+4. Update `run()` to use attribute access on the typed `configuration` parameter (e.g. `configuration.sources` instead of `configuration.get("sources", ())`)
+5. Remove any validation logic that becomes redundant (Pydantic validates types/defaults)
+
+### Nested schemas (arrays of objects)
+
+For fields like `sources: list[dict[str, str]]`, embed the nested item schema via `Field(json_schema_extra={"items": {...}})` — it overrides Pydantic's auto-generated `items` key.
+
+See `5e4be6fe` (auth_basic extension) for a full example.
+
+No class inheritance changes, no `configure()` method, no `TypedConfigExtension` — just the schema swap. The validated Pydantic model instance is passed as `configuration` to `run()`.
+
+### Verify
+
+- Run `uv run ruff check --fix src/flockwave/server/ext/<name>/extension.py` (or the single-file path)
+- Run `uv run ruff format src/flockwave/server/ext/<name>/extension.py`
+- Run `uv run python -c "import json; from flockwave.server.ext.<name>.extension import ConfigModel; print(json.dumps(ConfigModel.model_json_schema(), indent=2))"` and verify no `$defs` key in the output
+- Run `uv run pytest --cov=src --cov-report=html -vv -s -x` (full suite with coverage)
+- Run `pre-commit run --all-files` to catch any remaining issues (end-of-file, trailing whitespace, ruff, formatting, uv-lock)
+
+---
+
+## Key constraints
+
+- NEVER commit. Wait for user to review and commit.
+- NEVER push.
+- Work on one extension at a time.
+- Ask before making changes that differ from this pattern.

--- a/src/flockwave/server/ext/audit_log.py
+++ b/src/flockwave/server/ext/audit_log.py
@@ -18,12 +18,13 @@ from textwrap import dedent
 from time import time
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from pydantic import BaseModel, Field
 from trio import move_on_after, sleep, to_thread
 from trio.lowlevel import ParkingLot
 
 from flockwave.server.utils import constant
 
-from .base import Extension
+from .base import TypedConfigExtension
 
 if TYPE_CHECKING:
     from sqlite3 import Connection
@@ -334,7 +335,22 @@ class DbStorage(Storage):
             )
 
 
-class AuditLogExtension(Extension):
+class AuditLogConfig(BaseModel):
+    """Configuration model for the audit log extension."""
+
+    max_age: float = Field(
+        default=365,
+        ge=0,
+        title="Max age (days)",
+        description=(
+            "Maximum age of entries in the audit log, in days. Log entries "
+            "older than the given number of days are periodically removed from "
+            "the audit log. Zero means no limit."
+        ),
+    )
+
+
+class AuditLogExtension(TypedConfigExtension[AuditLogConfig]):
     """Extension that provides other extensions with an append-only audit log
     database where other extensions can register events.
 
@@ -377,21 +393,11 @@ class AuditLogExtension(Extension):
         self._entries.append(Entry(time(), component, type, data))
         self._parking_lot.unpark()
 
-    def configure(self, configuration: dict[str, Any]) -> None:
+    def configure(self, configuration: AuditLogConfig) -> None:
         db_path = self.get_data_dir() / "log.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
-        maybe_max_age = configuration.get("max_age")
-        if maybe_max_age is None:
-            self.max_age_days = 365  # default
-        elif (
-            maybe_max_age
-            and isinstance(maybe_max_age, (int, float))
-            and maybe_max_age > 0
-        ):
-            self.max_age_days = float(maybe_max_age)
-        else:
-            self.max_age_days = 0  # unlimited
+        self.max_age_days = configuration.max_age
 
         self._storage = DbStorage(db_path)
 
@@ -471,18 +477,4 @@ class AuditLogExtension(Extension):
 
 construct = AuditLogExtension
 description = "Audit log provider for other extensions"
-schema = {
-    "properties": {
-        "max_age": {
-            "title": "Max age (days)",
-            "description": (
-                "Maximum age of entries in the audit log, in days. Log entries "
-                "older than the given number of days are periodically removed from "
-                "the audit log. Zero means no limit."
-            ),
-            "type": "number",
-            "minimum": 0,
-            "default": 365,
-        }
-    }
-}
+schema = AuditLogConfig

--- a/src/flockwave/server/ext/auth_basic.py
+++ b/src/flockwave/server/ext/auth_basic.py
@@ -14,6 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel, Field
 from trio import sleep_forever
 
 from flockwave.server.ext.auth import AuthenticationExtensionAPI
@@ -179,6 +180,54 @@ def create_validator_from_config(
 # ############################################################################
 
 
+class AuthBasicConfig(BaseModel):
+    """Configuration model for the auth_basic extension."""
+
+    sources: list[dict[str, str]] = Field(
+        default=[],
+        title="Password data sources",
+        description=(
+            "WARNING: do not use explicit username-password pairs as these "
+            "are stored in plain text in the configuration file. Use another "
+            "data source in production."
+        ),
+        json_schema_extra={
+            "format": "table",
+            "items": {
+                "type": "object",
+                "options": {"disable_properties": False},
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "title": "Type",
+                        "description": "Type of the data source",
+                        "default": PasswordDataSourceType.HTPASSWD.id,
+                        "enum": [e.id for e in PasswordDataSourceType],
+                        "options": {
+                            "enum_titles": [
+                                e.description for e in PasswordDataSourceType
+                            ]
+                        },
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": (
+                            "The data source itself. For Apache htpasswd files, "
+                            "this must be the path to the htpasswd file. For "
+                            "explicit username-password pairs, this must be the "
+                            "username and the password, separated by whitespace."
+                        ),
+                    },
+                },
+            },
+        },
+    )
+
+
+# ############################################################################
+
+
 class BasicAuthentication(AuthenticationMethod):
     """Implementation of a basic username-password-based authentication method."""
 
@@ -217,16 +266,9 @@ class BasicAuthentication(AuthenticationMethod):
         return "basic"
 
 
-async def run(app: SkybrushServer, configuration, logger: Logger):
+async def run(app: SkybrushServer, configuration: AuthBasicConfig, logger: Logger):
     auth = BasicAuthentication()
-    sources = configuration.get("sources", ())
-
-    if not hasattr(sources, "__iter__"):
-        logger.error(
-            "Invalid configuration; password data sources must be stored in an array"
-        )
-
-    for spec in sources:
+    for spec in configuration.sources:
         validator: PasswordValidator | None = None
 
         try:
@@ -250,45 +292,4 @@ async def run(app: SkybrushServer, configuration, logger: Logger):
 
 dependencies = ("auth",)
 description = "Basic username-password based authentication"
-schema = {
-    "properties": {
-        "sources": {
-            "title": "Password data sources",
-            "type": "array",
-            "format": "table",
-            "items": {
-                "type": "object",
-                "options": {"disable_properties": False},
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "title": "Type",
-                        "description": "Type of the data source",
-                        "default": PasswordDataSourceType.HTPASSWD.id,
-                        "enum": [e.id for e in PasswordDataSourceType],
-                        "options": {
-                            "enum_titles": [
-                                e.description for e in PasswordDataSourceType
-                            ]
-                        },
-                    },
-                    "value": {
-                        "type": "string",
-                        "title": "Value",
-                        "description": (
-                            "The data source itself. For Apache htpasswd files, "
-                            "this must be the path to the htpasswd file. For "
-                            "explicit username-password pairs, this must be the "
-                            "username and the password, separated by whitespace."
-                        ),
-                    },
-                },
-            },
-            "description": (
-                "WARNING: do not use explicit username-password pairs as these "
-                "are stored in plain text in the configuration file. Use another "
-                "data source in production."
-            ),
-        }
-    }
-}
+schema = AuthBasicConfig

--- a/src/flockwave/server/ext/logging.py
+++ b/src/flockwave/server/ext/logging.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from logging import Handler, Logger, getLogger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Literal
 
 from flockwave.logger.formatters import styles
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from flockwave.server.app import SkybrushServer
@@ -19,44 +20,60 @@ log_dir: Path | None = None
 LOG_FILENAME: str = "skybrushd.log"
 
 
-def load(app: "SkybrushServer", configuration: dict[str, Any], log: Logger):
+class LoggingConfig(BaseModel):
+    """Configuration model for the logging extension."""
+
+    folder: str = Field(
+        default="",
+        title="Full, absolute path to the logging folder",
+        description=(
+            "Log files will be stored in this folder. Leave empty to use "
+            "the default log folder."
+        ),
+    )
+
+    format: Literal["tabular", "json"] = Field(
+        default="tabular",
+        title="Format of the log file",
+        json_schema_extra={
+            "options": {"enum_titles": ["Tabular", "JSON"]},
+        },
+    )
+
+    size: int = Field(
+        default=1000000,
+        ge=0,
+        title="Maximum log file size",
+        description=(
+            "Maximum allowed size of a log file, in bytes. Log files will be "
+            "rotated when they reach this size. Use zero for unlimited logs "
+            "(i.e. no rotation)."
+        ),
+    )
+
+    keep: int = Field(
+        default=0,
+        ge=0,
+        title="Number of backups to keep",
+        description="Set to zero to keep all log files",
+    )
+
+
+def load(app: "SkybrushServer", configuration: LoggingConfig, log: Logger):
     global handler
 
-    log_dir = Path(str(configuration.get("folder", "")) or app.dirs.user_log_dir)
+    log_dir = Path(configuration.folder or app.dirs.user_log_dir)
     log.info(f"Storing logs in '{log_dir}'")
 
-    format_str = str(configuration.get("format", "tabular"))
+    format_str = configuration.format
     try:
         formatter = styles[format_str]
     except KeyError:
         log.warning(f"Unknown log format: {format_str!r}, assuming tabular")
         formatter = styles["tabular"]
 
-    size_limit_str = str(configuration.get("size", "0"))
-    try:
-        size_limit = int(size_limit_str)
-    except ValueError:
-        log.warning(
-            f"Invalid maximum log file size: {size_limit_str!r}, assuming unlimited"
-        )
-        size_limit = 0
-
-    if size_limit < 0:
-        log.warning("Negative log file size limits are not allowed, assuming unlimited")
-        size_limit = 0
-
-    keep_str = str(configuration.get("keep", 0))
-    try:
-        backup_count = int(keep_str)
-    except ValueError:
-        backup_count = -1
-
-    if backup_count < 0:
-        log.warning(
-            f"Invalid backup count: {keep_str!r}, assuming that all logs should be kept"
-        )
-        backup_count = 0
-
+    size_limit = configuration.size
+    backup_count = configuration.keep
     try:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_dir_exists = True
@@ -90,33 +107,4 @@ def unload(app: "SkybrushServer"):
 
 
 description = "Routing of log messages to a logging folder on the disk"
-schema = {
-    "properties": {
-        "folder": {
-            "type": "string",
-            "title": "Full, absolute path to the logging folder",
-            "description": "Log files will be stored in this folder. Leave empty to use the default log folder.",
-            "default": "",
-        },
-        "format": {
-            "type": "string",
-            "enum": ["tabular", "json"],
-            "title": "Format of the log file",
-            "default": "tabular",
-            "options": {"enum_titles": ["Tabular", "JSON"]},
-        },
-        "size": {
-            "type": "integer",
-            "minValue": 0,
-            "title": "Maximum log file size",
-            "description": "Maximum allowed size of a log file, in bytes. Log files will be rotated when they reach this size. Use zero for unlimited logs (i.e. no rotation).",
-            "default": 1000000,
-        },
-        "keep": {
-            "type": "integer",
-            "minValue": 0,
-            "title": "Number of backups to keep",
-            "description": "Set to zero to keep all log files",
-        },
-    }
-}
+schema = LoggingConfig

--- a/src/flockwave/server/ext/rc_udp.py
+++ b/src/flockwave/server/ext/rc_udp.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from flockwave.connections import create_connection
 from flockwave.connections.socket import UDPListenerConnection
 from flockwave.networking import format_socket_address
+from pydantic import BaseModel, Field
 from trio import TooSlowError, fail_after
 
 from flockwave.server.ports import suggest_port_number_for_service, use_port
@@ -27,27 +28,91 @@ SERVICE: str = "rcin"
 """Name of the service that we use to derive a default port number."""
 
 
-async def run(app: SkybrushServer, configuration, log):
-    host = configuration.get("host", "127.0.0.1")
-    port = configuration.get("port", suggest_port_number_for_service(SERVICE))
+class RcUdpConfig(BaseModel):
+    """Configuration model for the RC UDP input extension."""
+
+    host: str = Field(
+        default="127.0.0.1",
+        title="Host",
+        description=(
+            "IP address of the host that the server should listen for incoming "
+            "UDP datagrams. Use an empty string to listen on all interfaces, or "
+            "127.0.0.1 to listen on localhost only"
+        ),
+        json_schema_extra={"propertyOrder": 10},
+    )
+
+    port: int = Field(
+        default=suggest_port_number_for_service(SERVICE),
+        ge=1,
+        le=65535,
+        title="Port",
+        description=(
+            "Port that the server should listen on. Untick the checkbox to "
+            "let the server derive the port number from its own base port."
+        ),
+        json_schema_extra={"propertyOrder": 20, "required": False},
+    )
+
+    bytesPerChannel: int = Field(
+        default=2,
+        ge=1,
+        le=2,
+        title="Bytes per channel",
+        description="Number of bytes per channel in each UDP packet",
+    )
+
+    endianness: Literal["big", "little"] = Field(
+        default="little",
+        title="Endianness",
+        description="Endianness of each incoming packet",
+        json_schema_extra={
+            "options": {
+                "enum_titles": [
+                    "Big endian (network byte order, MSB first)",
+                    "Little endian (LSB first)",
+                ]
+            },
+        },
+    )
+
+    range: list[int] | None = Field(
+        default=None,
+        title="Override channel range",
+        json_schema_extra={
+            "format": "table",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {"type": "integer"},
+            "required": False,
+        },
+    )
+
+    timeout: float = Field(
+        default=1.0,
+        ge=0,
+        title="Timeout",
+        description=(
+            "Number of seconds that must pass without receiving a UDP "
+            "packet to consider the RC connection as lost. Zero means "
+            "to disable the timeout."
+        ),
+    )
+
+
+async def run(app: SkybrushServer, configuration: RcUdpConfig, log):
+    host = configuration.host
+    port = configuration.port
     formatted_address = format_socket_address((host, port))
 
-    endianness = str(configuration.get("endianness", "little")).lower()
-    bytes_per_channel = int(configuration.get("bytesPerChannel", 2))
-    if endianness not in ("big", "little"):
-        log.error("Endianness must be 'big' or 'little', disabling extension")
-        return
-    if bytes_per_channel != 1 and bytes_per_channel != 2:
-        log.error("Bytes per RC channel must be 1 or 2, disabling extension")
-        return
+    endianness = configuration.endianness
+    bytes_per_channel = configuration.bytesPerChannel
 
-    timeout = float(configuration.get("timeout", 1))
-    if timeout < 0:
-        timeout = 0
-    if timeout == 0:
+    timeout = configuration.timeout
+    if timeout <= 0:
         timeout = float("inf")
 
-    value_range = parse_range(configuration.get("range"))
+    value_range = parse_range(configuration.range)
 
     decoder = (
         decode_one_byte_per_channel
@@ -189,72 +254,4 @@ async def handle_udp_datagrams(
 dependencies = ("rc",)
 description = "RC input source using UDP datagrams"
 tags = "experimental"
-schema = {
-    "properties": {
-        "host": {
-            "type": "string",
-            "title": "Host",
-            "description": (
-                "IP address of the host that the server should listen for incoming "
-                "UDP datagrams. Use an empty string to listen on all interfaces, or "
-                "127.0.0.1 to listen on localhost only"
-            ),
-            "default": "127.0.0.1",
-            "propertyOrder": 10,
-        },
-        "port": {
-            "type": "integer",
-            "title": "Port",
-            "description": (
-                "Port that the server should listen on. Untick the checkbox to "
-                "let the server derive the port number from its own base port."
-            ),
-            "minimum": 1,
-            "maximum": 65535,
-            "default": suggest_port_number_for_service(SERVICE),
-            "required": False,
-            "propertyOrder": 20,
-        },
-        "bytesPerChannel": {
-            "type": "integer",
-            "title": "Bytes per channel",
-            "minimum": 1,
-            "maximum": 2,
-            "default": 2,
-            "description": "Number of bytes per channel in each UDP packet",
-        },
-        "endianness": {
-            "type": "string",
-            "title": "Endianness",
-            "description": "Endianness of each incoming packet",
-            "default": "little",
-            "enum": ["big", "little"],
-            "options": {
-                "enum_titles": [
-                    "Big endian (network byte order, MSB first)",
-                    "Little endian (LSB first)",
-                ]
-            },
-        },
-        "range": {
-            "title": "Override channel range",
-            "type": "array",
-            "format": "table",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {"type": "integer"},
-            "required": False,
-        },
-        "timeout": {
-            "title": "Timeout",
-            "type": "number",
-            "minimum": 0,
-            "default": 1,
-            "description": (
-                "Number of seconds that must pass without receiving a UDP "
-                "packet to consider the RC connection as lost. Zero means "
-                "to disable the timeout."
-            ),
-        },
-    }
-}
+schema = RcUdpConfig

--- a/src/flockwave/server/ext/show/extension.py
+++ b/src/flockwave/server/ext/show/extension.py
@@ -4,13 +4,14 @@ from collections.abc import Sequence
 from contextlib import ExitStack
 from logging import Logger
 from math import inf
-from typing import Any
+from typing import Annotated, Any
 
 from flockwave.concurrency import CancellableTaskGroup
+from pydantic import BaseModel, Field, WithJsonSchema
 from trio import Nursery, TooSlowError, fail_after, open_nursery, sleep_forever
 from trio_util import periodic
 
-from flockwave.server.ext.base import Extension
+from flockwave.server.ext.base import TypedConfigExtension
 from flockwave.server.ext.clocks import ClocksExtensionAPI
 from flockwave.server.ext.signals import SignalsExtensionAPI
 from flockwave.server.model.clock import Clock
@@ -23,7 +24,41 @@ from .logging import ShowUploadLoggingMiddleware
 __all__ = ("construct", "dependencies", "description")
 
 
-class DroneShowExtension(Extension):
+class ShowConfig(BaseModel):
+    """Configuration model for the drone show extension."""
+
+    default_start_method: Annotated[
+        StartMethod,
+        WithJsonSchema(
+            {
+                "type": "string",
+                "enum": [m.value for m in StartMethod],
+                "options": {
+                    "enum_titles": [m.describe() for m in StartMethod],
+                },
+            }
+        ),
+    ] = Field(
+        default=StartMethod.RC,
+        title="Default start method for shows",
+    )
+
+    point_of_no_return_seconds: int = Field(
+        default=-10,
+        title="Point of no return for clock synchronization (seconds)",
+        description=(
+            "The number of seconds elapsed on the show clock that acts as "
+            'a "point of no return" threshold. The show clock will not '
+            "be synchronized to an external timecode any more if it is "
+            "running and it is beyond this time (in seconds). Stopping the "
+            "external timecode will still stop the clock even if it is "
+            "beyond the point of no return. Typically you want to set this "
+            "to a negative value."
+        ),
+    )
+
+
+class DroneShowExtension(TypedConfigExtension[ShowConfig]):
     """Extension that prepares the server to be able to manage drone shows.
 
     The extension provides three signals via the `signals` extension; `show:start`
@@ -62,6 +97,19 @@ class DroneShowExtension(Extension):
 
         self._config = DroneShowConfiguration()
         self._lights = LightConfiguration()
+
+    def configure(self, configuration: ShowConfig) -> None:
+        self._config.start_method = StartMethod(configuration.default_start_method)
+        self._clock_sync.point_of_no_return_seconds = (
+            configuration.point_of_no_return_seconds
+        )
+        self.log.info(
+            "Default show start method: %s", self._config.start_method.describe()
+        )
+        self.log.info(
+            "Timecode synchronization suspends at T = %d seconds",
+            configuration.point_of_no_return_seconds,
+        )
 
     def exports(self) -> dict[str, Any]:
         return {
@@ -126,12 +174,12 @@ class DroneShowExtension(Extension):
         except Exception as ex:
             return hub.acknowledge(message, outcome=False, reason=str(ex))
 
-    async def run(self, app, configuration, logger):
+    async def run(self, app):
         self._clock = ShowClock()
         self._end_clock = ShowEndClock()
 
-        self._clock_sync.log = logger
-        self._end_clock_sync.log = logger
+        self._clock_sync.log = self.log
+        self._end_clock_sync.log = self.log
 
         handlers = {
             "SHOW-CFG": self.handle_SHOW_CFG,
@@ -139,31 +187,6 @@ class DroneShowExtension(Extension):
             "SHOW-SETCFG": self.handle_SHOW_SETCFG,
             "SHOW-SETLIGHTS": self.handle_SHOW_SETLIGHTS,
         }
-
-        self._config.start_method = StartMethod(
-            configuration.get("default_start_method", "rc")
-        )
-
-        try:
-            point_of_no_return_seconds = int(
-                configuration.get("point_of_no_return_seconds", -10)
-            )
-        except ValueError:
-            self.log.warning(
-                "Invalid value for 'point_of_no_return_seconds' in configuration, "
-                "using default value of -10 seconds"
-            )
-            point_of_no_return_seconds = -10
-
-        self._clock_sync.point_of_no_return_seconds = point_of_no_return_seconds
-
-        self.log.info(
-            "Default show start method: %s", self._config.start_method.describe()
-        )
-        self.log.info(
-            "Timecode synchronization suspends at T = %d seconds",
-            point_of_no_return_seconds,
-        )
 
         async with open_nursery() as self._nursery:
             assert self._nursery is not None
@@ -433,30 +456,4 @@ class DroneShowExtension(Extension):
 construct = DroneShowExtension
 dependencies = ("clocks", "signals")
 description = "Support for managing drone shows"
-schema = {
-    "properties": {
-        "default_start_method": {
-            "type": "string",
-            "title": "Default start method for shows",
-            "enum": [StartMethod.RC.value, StartMethod.AUTO.value],
-            "default": StartMethod.RC.value,
-            "options": {
-                "enum_titles": [StartMethod.RC.describe(), StartMethod.AUTO.describe()],
-            },
-        },
-        "point_of_no_return_seconds": {
-            "type": "number",
-            "title": "Point of no return for clock synchronization (seconds)",
-            "description": (
-                "The number of seconds elapsed on the show clock that acts as "
-                'a "point of no return" threshold. The show clock will not '
-                "be synchronized to an external timecode any more if it is "
-                "running and it is beyond this time (in seconds). Stopping the "
-                "external timecode will still stop the clock even if it is "
-                "beyond the point of no return. Typically you want to set this "
-                "to a negative value."
-            ),
-            "default": -10,
-        },
-    }
-}
+schema = ShowConfig

--- a/src/flockwave/server/ext/tcp.py
+++ b/src/flockwave/server/ext/tcp.py
@@ -19,6 +19,7 @@ from flockwave.connections import IPAddressAndPort
 from flockwave.encoders.json import create_json_encoder
 from flockwave.networking import format_socket_address
 from flockwave.parsers.json import create_json_parser
+from pydantic import BaseModel, Field
 from trio import (
     BrokenResourceError,
     CapacityLimiter,
@@ -199,11 +200,47 @@ async def handle_message(message: Any, client, *, limit: CapacityLimiter) -> Non
 ############################################################################
 
 
-async def run(app: SkybrushServer, configuration, logger: Logger):
+class TcpConfig(BaseModel):
+    """Configuration model for the TCP extension."""
+
+    host: str = Field(
+        default="",
+        title="Host",
+        description=(
+            "IP address of the host that the server should listen on for "
+            "incoming TCP connections. Use an empty string to listen on all "
+            "interfaces, or 127.0.0.1 to listen on localhost only"
+        ),
+        json_schema_extra={"propertyOrder": 10},
+    )
+
+    port: int = Field(
+        default=suggest_port_number_for_service("tcp"),
+        ge=1,
+        le=65535,
+        title="Port",
+        description=(
+            "Port that the server should listen on for incoming TCP connections. "
+            "Untick the checkbox to let the server derive the port number from "
+            "its own base port."
+        ),
+        json_schema_extra={"propertyOrder": 20, "required": False},
+    )
+
+    pool_size: int = Field(
+        default=1000,
+        ge=1,
+        title="Connection pool size",
+        description="Maximum number of concurrent TCP connections to handle.",
+        json_schema_extra={"propertyOrder": 30},
+    )
+
+
+async def run(app: SkybrushServer, configuration: TcpConfig, logger: Logger):
     """Background task that is active while the extension is loaded."""
-    host = str(configuration.get("host", ""))
-    port = int(configuration.get("port", suggest_port_number_for_service("tcp")))
-    pool_size = int(configuration.get("pool_size", 1000))
+    host = configuration.host
+    port = configuration.port
+    pool_size = configuration.pool_size
     address = host, port
 
     with ExitStack() as stack:
@@ -225,40 +262,4 @@ async def run(app: SkybrushServer, configuration, logger: Logger):
 
 
 description = "TCP socket-based communication channel"
-schema = {
-    "properties": {
-        "host": {
-            "type": "string",
-            "title": "Host",
-            "description": (
-                "IP address of the host that the server should listen on for "
-                "incoming TCP connections. Use an empty string to listen on all "
-                "interfaces, or 127.0.0.1 to listen on localhost only"
-            ),
-            "default": "",
-            "propertyOrder": 10,
-        },
-        "port": {
-            "type": "integer",
-            "title": "Port",
-            "description": (
-                "Port that the server should listen on for incoming TCP connections. "
-                "Untick the checkbox to let the server derive the port number from "
-                "its own base port."
-            ),
-            "minimum": 1,
-            "maximum": 65535,
-            "default": suggest_port_number_for_service("tcp"),
-            "required": False,
-            "propertyOrder": 20,
-        },
-        "pool_size": {
-            "type": "integer",
-            "title": "Connection pool size",
-            "minimum": 1,
-            "description": ("Maximum number of concurrent TCP connections to handle."),
-            "default": 1000,
-            "propertyOrder": 30,
-        },
-    }
-}
+schema = TcpConfig

--- a/src/flockwave/server/ext/timesync/extension.py
+++ b/src/flockwave/server/ext/timesync/extension.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 from contextlib import ExitStack
 from typing import Any, ContextManager, Protocol
 
-from flockwave.server.ext.base import Extension
+from flockwave.server.ext.base import TypedConfigExtension
 from flockwave.server.message_hub import MessageHub
 from flockwave.server.model.client import Client
 from flockwave.server.model.log import Severity
 from flockwave.server.model.messages import FlockwaveMessage, FlockwaveResponse
 
-from .constants import (
-    DEFAULT_OFFSET_LOG_THRESHOLD,
-    DEFAULT_SOURCE_EXPIRY_THRESHOLD,
-    DEFAULT_SYNC_THRESHOLD,
-)
 from .manager import TimeSource, TimeSyncManager
 from .model import TimeSyncSnapshot
 from .types import TimeSyncState
@@ -29,7 +24,10 @@ __all__ = (
 )
 
 
-class TimeSyncExtension(Extension):
+from .schema import TimeSyncConfig
+
+
+class TimeSyncExtension(TypedConfigExtension[TimeSyncConfig]):
     """Extension that tracks server wall-clock synchronization status."""
 
     _manager: TimeSyncManager
@@ -40,21 +38,13 @@ class TimeSyncExtension(Extension):
         super().__init__()
         self._manager = TimeSyncManager()
 
-    def configure(self, configuration: dict[str, Any]) -> None:
+    def configure(self, configuration: TimeSyncConfig) -> None:
         """Updates the extension configuration from the extension settings."""
         super().configure(configuration)
         self._manager.configure(
-            sync_threshold=float(
-                configuration.get("sync_threshold", DEFAULT_SYNC_THRESHOLD)
-            ),
-            source_expiry_threshold=float(
-                configuration.get(
-                    "source_expiry_threshold", DEFAULT_SOURCE_EXPIRY_THRESHOLD
-                )
-            ),
-            offset_log_threshold=float(
-                configuration.get("offset_log_threshold", DEFAULT_OFFSET_LOG_THRESHOLD)
-            ),
+            sync_threshold=configuration.sync_threshold,
+            source_expiry_threshold=configuration.source_expiry_threshold,
+            offset_log_threshold=configuration.offset_log_threshold,
             log=self.log,
         )
 

--- a/src/flockwave/server/ext/timesync/schema.py
+++ b/src/flockwave/server/ext/timesync/schema.py
@@ -1,5 +1,7 @@
 """Configuration schema for the `timesync` extension."""
 
+from pydantic import BaseModel, Field
+
 from .constants import (
     DEFAULT_OFFSET_LOG_THRESHOLD,
     DEFAULT_SOURCE_EXPIRY_THRESHOLD,
@@ -9,37 +11,38 @@ from .constants import (
 __all__ = ("schema",)
 
 
-schema = {
-    "properties": {
-        "sync_threshold": {
-            "type": "number",
-            "title": "Sync threshold",
-            "description": (
-                "Maximum absolute clock offset, in seconds, for the local server "
-                "clock to be considered synchronized to wall clock time."
-            ),
-            "default": DEFAULT_SYNC_THRESHOLD,
-            "minimum": 0,
-        },
-        "source_expiry_threshold": {
-            "type": "number",
-            "title": "Source expiry threshold",
-            "description": (
-                "Maximum age of a timestamp submission, in seconds, after which "
-                "it is ignored."
-            ),
-            "default": DEFAULT_SOURCE_EXPIRY_THRESHOLD,
-            "exclusiveMinimum": 0,
-        },
-        "offset_log_threshold": {
-            "type": "number",
-            "title": "Offset log threshold",
-            "description": (
-                "Minimum change in the selected clock offset, in seconds, that "
-                "triggers a new log message while the synchronization state stays the same."
-            ),
-            "default": DEFAULT_OFFSET_LOG_THRESHOLD,
-            "minimum": 0,
-        },
-    }
-}
+class TimeSyncConfig(BaseModel):
+    """Configuration model for the timesync extension."""
+
+    sync_threshold: float = Field(
+        default=DEFAULT_SYNC_THRESHOLD,
+        ge=0,
+        title="Sync threshold",
+        description=(
+            "Maximum absolute clock offset, in seconds, for the local server "
+            "clock to be considered synchronized to wall clock time."
+        ),
+    )
+
+    source_expiry_threshold: float = Field(
+        default=DEFAULT_SOURCE_EXPIRY_THRESHOLD,
+        gt=0,
+        title="Source expiry threshold",
+        description=(
+            "Maximum age of a timestamp submission, in seconds, after which "
+            "it is ignored."
+        ),
+    )
+
+    offset_log_threshold: float = Field(
+        default=DEFAULT_OFFSET_LOG_THRESHOLD,
+        ge=0,
+        title="Offset log threshold",
+        description=(
+            "Minimum change in the selected clock offset, in seconds, that "
+            "triggers a new log message while the synchronization state stays the same."
+        ),
+    )
+
+
+schema = TimeSyncConfig

--- a/src/flockwave/server/ext/udp.py
+++ b/src/flockwave/server/ext/udp.py
@@ -17,6 +17,7 @@ from flockwave.connections import IPAddressAndPort
 from flockwave.encoders.json import create_json_encoder
 from flockwave.networking import create_socket, format_socket_address
 from flockwave.parsers.json import create_json_parser
+from pydantic import BaseModel, Field
 from trio import CapacityLimiter, aclose_forcefully, open_nursery
 from trio.socket import SOCK_DGRAM
 
@@ -145,13 +146,49 @@ async def handle_message_safely(
 ############################################################################
 
 
-async def run(app: "SkybrushServer", configuration: dict[str, Any], logger: Logger):
+class UdpConfig(BaseModel):
+    """Configuration model for the UDP extension."""
+
+    host: str = Field(
+        default="",
+        title="Host",
+        description=(
+            "IP address of the host that the server should listen on for "
+            "incoming UDP packets. Use an empty string to listen on all "
+            "interfaces, or 127.0.0.1 to listen on localhost only"
+        ),
+        json_schema_extra={"propertyOrder": 10},
+    )
+
+    port: int = Field(
+        default=suggest_port_number_for_service("udp"),
+        ge=1,
+        le=65535,
+        title="Port",
+        description=(
+            "Port that the server should listen on for incoming UDP packets. "
+            "Untick the checkbox to let the server derive the port number from "
+            "its own base port."
+        ),
+        json_schema_extra={"propertyOrder": 20, "required": False},
+    )
+
+    pool_size: int = Field(
+        default=1000,
+        ge=1,
+        title="Request handler pool size",
+        description="Maximum number of concurrent UDP requests to handle.",
+        json_schema_extra={"propertyOrder": 30},
+    )
+
+
+async def run(app: "SkybrushServer", configuration: UdpConfig, logger: Logger):
     """Background task that is active while the extension is loaded."""
-    host = configuration.get("host", "")
-    port = configuration.get("port", suggest_port_number_for_service("udp"))
+    host = configuration.host
+    port = configuration.port
 
     address = host, port
-    pool_size = configuration.get("pool_size", 1000)
+    pool_size = configuration.pool_size
 
     sock = create_socket(SOCK_DGRAM)
     await sock.bind(address)
@@ -180,40 +217,4 @@ async def run(app: "SkybrushServer", configuration: dict[str, Any], logger: Logg
 
 
 description = "UDP socket-based communication channel"
-schema = {
-    "properties": {
-        "host": {
-            "type": "string",
-            "title": "Host",
-            "description": (
-                "IP address of the host that the server should listen on for "
-                "incoming UDP packets. Use an empty string to listen on all "
-                "interfaces, or 127.0.0.1 to listen on localhost only"
-            ),
-            "default": "",
-            "propertyOrder": 10,
-        },
-        "port": {
-            "type": "integer",
-            "title": "Port",
-            "description": (
-                "Port that the server should listen on for incoming UDP packets. "
-                "Untick the checkbox to let the server derive the port number from "
-                "its own base port."
-            ),
-            "minimum": 1,
-            "maximum": 65535,
-            "default": suggest_port_number_for_service("udp"),
-            "required": False,
-            "propertyOrder": 20,
-        },
-        "pool_size": {
-            "type": "integer",
-            "title": "Request handler pool size",
-            "minimum": 1,
-            "description": ("Maximum number of concurrent UDP requests to handle."),
-            "default": 1000,
-            "propertyOrder": 30,
-        },
-    }
-}
+schema = UdpConfig


### PR DESCRIPTION
In this PR I tried to automate refactoring server extension configs from pure dict to Pydantic representations. I added an agent skill to perform such conversions. So far mostly simple extensions are converted, and it is not trivial sometimes to convert more complex ones.

## Extensions to convert:

- [x] audit_log
- [x] auth
- [x] auth_basic
- [ ] beacon (schema = {})
- [ ] clocks (schema = {})
- [ ] console_status (schema = {})
- [ ] crazyflie (embedded FenceConfiguration, IntEnum fields)
- [ ] debug (schema = {})
- [ ] ext_manager (schema = {})
- [ ] frontend (schema = {})
- [x] gps
- [ ] hotplug (schema = {})
- [x] http
- [x] http_server
- [x] insomnia
- [x] kp_index
- [ ] license (schema = {})
- [ ] location (embedded `fixed` object)
- [x] location_from_uavs
- [x] logging
- [ ] lps (schema = {})
- [ ] magnetic_field (schema = {})
- [ ] mavlink (deeply nested, additionalProperties)
- [ ] missions (schema = {})
- [ ] motion_capture (nested array of objects)
- [ ] ntrip (schema = {})
- [ ] rc (schema = {})
- [x] rc_udp
- [ ] rtk (uses get_schema() function)
- [x] show
- [ ] signals (schema = {})
- [ ] socketio (schema = {})
- [ ] ssdp (uses get_schema() function)
- [ ] system_clock (schema = {})
- [x] tcp
- [x] timesync
- [x] udp
- [ ] virtual_uavs (embedded takeoff_area object)
- [ ] weather (schema = {})
- [ ] webui (schema = {})
